### PR TITLE
Make MICRO_8088 settable from command line

### DIFF
--- a/src/GLABIOS.ASM
+++ b/src/GLABIOS.ASM
@@ -298,7 +298,10 @@ FE_CPU_CFG		=	100b			; boot to 9.54 MHz, 4 RAM WS (safest)
 POST_TEST_PIT_1	=	0			; FE2010A chipset cannot read timer 1
 SW1_FLP		=	01b			; SW1 5/6 Max # of floppy drives (0-1)
 TURBO_TYPE		=	TURBO_REV		; always use reverse
+
+	IFNDEF MICRO_8088
 MICRO_8088		=	0			; build for micro_8088 / NuXT
+	ENDIF
 
 	IF MICRO_8088 EQ 1
 ;----------------------------------------------------------------------------;


### PR DESCRIPTION
I am doing some automated building of Micro 8088/NuXT BIOS images and would like to avoid having to patch GLABIOS.ASM before building - it's fragile and likely to break in the future.

This very simple patch makes it possible to set `MICRO_8088` on the command line when assembling.